### PR TITLE
Fix maven war plugin. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,14 +176,9 @@
 
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.2</version>
                 <configuration>
-                    <attachClasses>true</attachClasses>
-                    <webResources>
-                        <resource>
-                            <directory>src/main/java/app</directory>
-                            <filtering>true</filtering>
-                        </resource>
-                    </webResources>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Поменял потому что после того, как убрали web.xml он стал крашиться, так как не находил его. И в итоге некоторые жизненные стадии в мавене (package/verify и тд) не работали. 
Плюс была не указана версия и потому прилетали "предупреждения". 