### PR TITLE
Fix checkstyle

### DIFF
--- a/checkstyle-suppressions
+++ b/checkstyle-suppressions
@@ -11,5 +11,4 @@
     <suppress checks="FinalParametersCheck" files="."/>
     <suppress checks="HiddenFieldCheck" files="."/>
     <suppress checks="AvoidInlineConditionalsCheck" files="."/>
-    <suppress checks="AvoidStarImportCheck" files="."/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <phase>verify</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
Это чтобы нерабочие тесты не мешали работать чекстайлу. 
Там фаза выполнения была настроена на verify, а оно идет после test, по разным причинам тесты не работают. И поэтому я решил поставить фазу выполнения на compile, т.е. перед test. 

И еще убрал супресс на импорт *. 